### PR TITLE
Enable toc extension to link directly to headings in any Markdown content. Fix #10

### DIFF
--- a/djangocon_2020/site/templatetags/markdown_extras.py
+++ b/djangocon_2020/site/templatetags/markdown_extras.py
@@ -16,7 +16,8 @@ def markdown(value):
         'extra',
         'nl2br',
         'sane_lists',
-        'meta'
+        'meta',
+        'toc',
         ])
     r['html'] = m.convert(f)
     r['meta'] = m.Meta


### PR DESCRIPTION
Implements my suggestion from #10. This seems to be working as expected, with no other change to the site. For example http://127.0.0.1:8000/conduct/code_of_conduct/#guidelines-for-reporting-incidents.

@magamig I realise this doesn’t follow your suggestion – I don’t like the perspective of having to divide pages into multiple files just to get those links. If you still prefer it though, I’ll happily drop this and move on to splitting the code of conduct and response guide.