### PR TITLE
Add Code of Conduct Active Response Ensurers team to CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,12 @@ Everybody who participates in DjangoCon Europe in one way or another is required
 
 The organizers will introduce a Code of Conduct team that will be primarily responsible for handling any incidents. The CoC applies before and throughout the event (including related activities such as social events, and social media). We have also published our [response guidelines](https://2020.djangocon.eu/conduct/response_guide/).
 
-The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu).
+The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu), and its members are (alphabetically):
+
+* Andrew Kinyua
+* Jesse Hunt
+* Rin (they/them)
+* Thibaud Colas (he/him)
 
 A big thank you to the DjangoCon Europe 2019 CoC team for the awesome CoC (which we adapted with some minor modifications) and the response guidelines (which we have adopted unedited from 2018).
 


### PR DESCRIPTION
Pending confirmation by the team