### PR TITLE
Add code of conduct team: take two

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ The organizers will introduce a Code of Conduct team that will be primarily resp
 The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu), and its members are (alphabetically):
 
 * Andrew Kinyua
-* Jesse Hunt
+* Jesse Hunt (he/him)
 * Rin (they/them)
 * Thibaud Colas (he/him)
 

--- a/djangocon_2020/content/conduct/code_of_conduct/code_of_conduct.md
+++ b/djangocon_2020/content/conduct/code_of_conduct/code_of_conduct.md
@@ -5,7 +5,12 @@ Everybody who participates in DjangoCon Europe in one way or another is required
 
 The organizers will introduce a Code of Conduct team that will be primarily responsible for handling any incidents. The CoC applies before and throughout the event (including related activities such as social events, and social media). We have also published our [response guidelines](/conduct/response_guide/).
 
-The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu).
+The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu), and its members are (alphabetically):
+
+* Andrew Kinyua
+* Jesse Hunt (he/him)
+* Rin (they/them)
+* Thibaud Colas (he/him)
 
 We would like to thank the DjangoCon Europe 2019 CoC team for the awesome CoC (which we adapted with some minor modifications) and the response guidelines (which we have adopted almost unedited from 2018).
 


### PR DESCRIPTION
Follow-up to #18 – we were missing Jesse’s pronouns, and I had only edited one of the two docs.